### PR TITLE
add func GetAfterExpirationAnchor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/wklken/go-cache
+
+go 1.16


### PR DESCRIPTION
`GetAfterExpirationAnchor(k string, timestampNano int64) (interface{}, bool)`

```
// GetAfterExpirationAnchor will do cache get by key and expiration anchor(a unix nano seconds, int64).
// if cache.Get in a loop with the same nano, the raw Get will call time.Now().UnixNano() each time,
// it will take a loop of cpu time!
// so, we add one more function to pass the UnixNano seconds as parameter.
```

related to https://github.com/TencentBlueKing/bk-iam-saas/issues/860